### PR TITLE
chore: Merge past fixes diverging from taxjar upstream

### DIFF
--- a/lib/vat_check/format.rb
+++ b/lib/vat_check/format.rb
@@ -10,7 +10,7 @@ class VatCheck
     def self.patterns
       @patterns ||= {
         'AT' => /\AATU[0-9]{8}\Z/,                                          # Austria
-        'BE' => /\ABE0[0-9]{9}\Z/,                                          # Belgium
+        'BE' => /\ABE[01][0-9]{9}\Z/,                                       # Belgium
         'BG' => /\ABG[0-9]{9,10}\Z/,                                        # Bulgaria
         'CY' => /\ACY[0-9]{8}[A-Z]\Z/,                                      # Cyprus
         'CZ' => /\ACZ[0-9]{8,10}\Z/,                                        # Czech Republic

--- a/lib/vat_check/requests.rb
+++ b/lib/vat_check/requests.rb
@@ -6,7 +6,7 @@ class VatCheck
       client = Savon.client(wsdl: 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl', follow_redirects: true, log: false, log_level: :debug, pretty_print_xml: false)
       country_code, vat_number = VatCheck::Utility.split(vat)
       begin
-        response = client.call(:check_vat, message: {country_code: country_code, vat_number: vat_number}, message_tag: :checkVat)
+        response = client.call(:check_vat, message: {country_code: country_code, vat_number: vat_number}, message_tag: :checkVat, soap_action: nil)
         response.to_hash[:check_vat_response].reject { |key| key == :@xmlns }
       rescue Savon::SOAPFault => e
         if !!(e.message =~ /MS_UNAVAILABLE/)

--- a/spec/vat_check/format_spec.rb
+++ b/spec/vat_check/format_spec.rb
@@ -4,6 +4,7 @@ describe VatCheck::Format do
   valid_vat_ids = [
     'ATU99999999',        # AT-Austria
     'BE0999999999',       # BE-Belgium
+    'BE1999999999',       # BE-Belgium
     'BG999999999',        # BG-Bulgaria
     'BG9999999999',       # BG-Bulgaria
     'CY99999999L',        # CY-Cyprus


### PR DESCRIPTION
This PR includes
- The forked + fixed branch we've relied on for some time, but which has not made it into taxjar's upstream: 
  - https://github.com/taxjar/vat_check/pull/7
- A new fix for the belgian VAT regex: [source](https://www.vatcalc.com/belgium/belgian-vat-number-format-changes/)
  - https://github.com/berislavbabic/vat_check/pull/1

